### PR TITLE
ci(travis): run commitlint on travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
   firefox: latest
 
 before_install:
+  - git fetch --unshallow # needed for commitlint
   - nvm i node
   - npm install
   - npm install -g greenkeeper-lockfile@1
@@ -31,6 +32,7 @@ before_script: greenkeeper-lockfile-update
 script :
   - npm run build-static
   - npm test -- --browsers $BROWSERS
+  - bash tools/lint-commits.sh # script lint commit messages, handles commits from forks and same repo
   - npm run lint-js
   - npm run lint-css
   - npm run lint-md

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "6.1.0",
   "description": "Application Framework for uPortal",
   "scripts": {
-    "commitmsg": "commitlint -e",
     "cz": "git-cz",
     "test": "karma start components/karma.conf.js --single-run",
     "build-static": "node tools/static/build.js",

--- a/tools/lint-commits.sh
+++ b/tools/lint-commits.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+set -u
+
+if [[ $TRAVIS_PULL_REQUEST_SLUG != "" && $TRAVIS_PULL_REQUEST_SLUG != $TRAVIS_REPO_SLUG ]]; then
+    # This is a Pull Request from a different slug, hence a forked repository
+    git remote add "$TRAVIS_PULL_REQUEST_SLUG" "https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git"
+    git fetch "$TRAVIS_PULL_REQUEST_SLUG"
+
+    # Use the fetched remote pointing to the source clone for comparison
+    TO="$TRAVIS_PULL_REQUEST_SLUG/$TRAVIS_PULL_REQUEST_BRANCH"
+else
+    # This is a Pull Request from the same remote, no clone repository
+    TO=$TRAVIS_COMMIT
+fi
+
+# Lint all commits in the PR
+# - Covers fork pull requests (when TO=slug/branch)
+# - Covers branch pull requests (when TO=branch)
+npx commitlint --from="$TRAVIS_BRANCH" --to="$TO"
+
+# Always lint the triggerig commit
+# - Covers direct commits
+npx commitlint --from="$TRAVIS_COMMIT"

--- a/tools/lint-commits.sh
+++ b/tools/lint-commits.sh
@@ -23,12 +23,14 @@ set -u
 
 if [[ $TRAVIS_PULL_REQUEST_SLUG != "" && $TRAVIS_PULL_REQUEST_SLUG != $TRAVIS_REPO_SLUG ]]; then
     # This is a Pull Request from a different slug, hence a forked repository
+    echo this is a pull request from fork
     git remote add "$TRAVIS_PULL_REQUEST_SLUG" "https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git"
     git fetch "$TRAVIS_PULL_REQUEST_SLUG"
 
     # Use the fetched remote pointing to the source clone for comparison
     TO="$TRAVIS_PULL_REQUEST_SLUG/$TRAVIS_PULL_REQUEST_BRANCH"
 else
+    echo this is an internal pull request
     # This is a Pull Request from the same remote, no clone repository
     TO=$TRAVIS_COMMIT
 fi
@@ -36,8 +38,11 @@ fi
 # Lint all commits in the PR
 # - Covers fork pull requests (when TO=slug/branch)
 # - Covers branch pull requests (when TO=branch)
+echo $TRAVIS_BRANCH
+echo $TO
 npx commitlint --from="$TRAVIS_BRANCH" --to="$TO"
 
 # Always lint the triggerig commit
 # - Covers direct commits
+echo $TRAVIS_COMMIT
 npx commitlint --from="$TRAVIS_COMMIT"

--- a/tools/lint-commits.sh
+++ b/tools/lint-commits.sh
@@ -1,4 +1,23 @@
 #!/bin/bash
+#
+# Licensed to Apereo under one or more contributor license
+# agreements. See the NOTICE file distributed with this work
+# for additional information regarding copyright ownership.
+# Apereo licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file
+# except in compliance with the License.  You may obtain a
+# copy of the License at the following location:
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 set -e
 set -u
 


### PR DESCRIPTION
removes `precommit` hook that verifies commit message locally.
Combined with #580 this removes all error level commit hooks.

Most recent local commit can still be checked with `npm run lint-commit`.

Travis CI now checks all commits in a feature branch to ensure they meet the formatting guidelines.

:notebook: I still see this as a step backward, checking if a commit message meets the conventional commit standard locally is a lot easier than rewriting history later.

part 2 of #535
part 1 is in #580

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
