### PR TITLE
build(maven): set Java 8 as target version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
   </scm>
 
   <properties>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <webapp.target.directory>${project.build.directory}/${project.build.finalName}</webapp.target.directory>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.license.plugin.ver>3.0</maven.license.plugin.ver>


### PR DESCRIPTION
Java 7 has been [End Of Lifed (EOL)](http://www.oracle.com/technetwork/java/eol-135779.html).
Java 8 is going to be [EOL](http://www.oracle.com/technetwork/java/eol-135779.html).
This updates compiler target to Java 8.
Soon we should look into a Java 9 upgrade.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
