### PR TITLE
ci(travis): allow Chrome to run on container environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
-
 sudo: false
 
 matrix:
@@ -8,11 +7,11 @@ matrix:
     - os: linux
       dist: trusty
       jdk: oraclejdk8
-      env: BROWSERS=ChromeHeadless,FirefoxHeadless
+      env: BROWSERS=ChromeHeadlessNoSandbox,FirefoxHeadless
     - os: linux
       dist: trusty
       jdk: openjdk7
-      env: BROWSERS=ChromeHeadless,FirefoxHeadless
+      env: BROWSERS=ChromeHeadlessNoSandbox,FirefoxHeadless
     - os: osx
       osx_image: xcode8.3
       env: BROWSERS=ChromeHeadless,Safari

--- a/components/karma.conf.js
+++ b/components/karma.conf.js
@@ -42,13 +42,13 @@ module.exports = function(config) {
 
         // TODO: remove this after official support is added
         customLaunchers: {
-            FirefoxHeadless: {
-                base: 'Firefox',
-                flags: ['-headless'],
-            },
+          ChromeHeadlessNoSandbox: {
+            base: 'ChromeHeadless',
+            flags: ['--no-sandbox'],
+          },
         },
 
-        browsers: ['ChromeHeadless'], // or 'Chrome'
+        browsers: ['ChromeHeadless', 'FirefoxHeadless'], // or 'Chrome'
 
         plugins: [
             'karma-htmlfile-reporter',


### PR DESCRIPTION
Use no sandbox mode on travis container environment to prevent error:
```
The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /opt/google/chrome/chrome-sandbox is owned by root and has mode 4755
```

reference: https://docs.travis-ci.com/user/chrome

Additionally the removes custom FirefoxHeadless browser setup, replacing it with the default task provided by the Karma runner.
With the FirefoxHeadless task being made official, it has been enabled by default for testing.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
